### PR TITLE
Zw working

### DIFF
--- a/scripts/data_collection/Island_nwp_ext_latlon.py
+++ b/scripts/data_collection/Island_nwp_ext_latlon.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 import httpx
 import typer
-from typing import List, Sequence
+from typing import List
 import xarray as xr
 from dotenv import load_dotenv
 from tqdm import tqdm


### PR DESCRIPTION
a single script to decide what data to download and how to save for dates pre to the NWP data upgrade in 2021-03-22 and post that date.

It also now collects different variables if the fc =0 (note: no cloud cover variables for the 0 fc hour pre the upgrade in 2021-03-22 but the script now adapts for his case).

Better error handling has been built in. If a file path does not exist or if data for a certain variable is corrupted the script will move on and try the next date/fc/path.

A step argument has now also been included which can be called using --step, when the script is ran, with either a single int or multiple ints separated by commas for example (-- step 3) or (--step 3,6,9,12)

When the loop is finished collecting the data, the date/fc/path or any missing data will be printed. (would be good to store this in a text file)